### PR TITLE
Add docker spec for scala code coverage

### DIFF
--- a/containers/scala/Dockerfile
+++ b/containers/scala/Dockerfile
@@ -2,9 +2,11 @@ FROM java:8u111-jdk
 
 ENV SCALA_VERSION 2.12.3
 ENV SBT_VERSION 0.13.8
-ENV HOME_DIR /home/ubuntu/
+ENV USER_IN_CONTAINER ubuntu
+ENV HOME_DIR /home/ubuntu
 
 RUN touch /usr/lib/jvm/java-1.8.0-openjdk-amd64/release
+RUN update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 RUN apt-get update && apt-get install -y \
 		              gradle \
@@ -15,24 +17,25 @@ RUN apt-get update && apt-get install -y \
 # Install Scala
 ## Piping curl directly in tar
 RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /home/ubuntu/ && \
-  echo >> $HOME_DIR/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> $HOME_DIR/.bashrc
+  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
+  echo >> /root/.bashrc && \
+  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
 
 # Install sbt
 RUN \
   curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
-  apt-get update && \
   apt-get install sbt && \
   sbt sbtVersion
 
-RUN echo "export PATH=$JAVA_HOME/bin:$PATH" >> $HOME_DIR/.bashrc
+RUN useradd --create-home --shell /bin/bash $USER_IN_CONTAINER
+USER $USER_IN_CONTAINER
 
-USER ubuntu
+RUN echo "export PATH=~/scala-$SCALA_VERSION/bin:$JAVA_HOME/bin:$PATH" >> $HOME_DIR/.bashrc
 
 WORKDIR $HOME_DIR
+
 ADD ./fetch_repo_and_collect_coverage.sh $HOME_DIR/fetch_repo_and_collect_coverage.sh
 
 ENTRYPOINT $HOME_DIR/fetch_repo_and_collect_coverage.sh ${REPO} ${TAG} ${CHALLENGE_ID}

--- a/containers/scala/Dockerfile
+++ b/containers/scala/Dockerfile
@@ -1,0 +1,35 @@
+FROM java:8u111-jdk
+
+ENV SCALA_VERSION 2.12.3
+ENV SBT_VERSION 0.13.8
+
+RUN touch /usr/lib/jvm/java-1.8.0-openjdk-amd64/release
+
+RUN echo "export PATH=$JAVA_HOME/bin:$PATH" >> /root/.bashrc
+
+RUN apt-get update && apt-get install -y \
+		              gradle \
+                              git \
+                              libxml2-utils \
+        --no-install-recommends && rm -r /var/lib/apt/lists/*
+
+# Install Scala
+## Piping curl directly in tar
+RUN \
+  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
+  echo >> /root/.bashrc && \
+  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+
+# Install sbt
+RUN \
+  curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get install sbt && \
+  sbt sbtVersion
+
+WORKDIR /home/ubuntu/
+ADD ./fetch_repo_and_collect_coverage.sh /home/ubuntu/fetch_repo_and_collect_coverage.sh
+
+ENTRYPOINT /home/ubuntu/fetch_repo_and_collect_coverage.sh ${REPO} ${TAG} ${CHALLENGE_ID}

--- a/containers/scala/Dockerfile
+++ b/containers/scala/Dockerfile
@@ -2,10 +2,9 @@ FROM java:8u111-jdk
 
 ENV SCALA_VERSION 2.12.3
 ENV SBT_VERSION 0.13.8
+ENV HOME_DIR /home/ubuntu/
 
 RUN touch /usr/lib/jvm/java-1.8.0-openjdk-amd64/release
-
-RUN echo "export PATH=$JAVA_HOME/bin:$PATH" >> /root/.bashrc
 
 RUN apt-get update && apt-get install -y \
 		              gradle \
@@ -16,9 +15,9 @@ RUN apt-get update && apt-get install -y \
 # Install Scala
 ## Piping curl directly in tar
 RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
-  echo >> /root/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /home/ubuntu/ && \
+  echo >> $HOME_DIR/.bashrc && \
+  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> $HOME_DIR/.bashrc
 
 # Install sbt
 RUN \
@@ -29,7 +28,11 @@ RUN \
   apt-get install sbt && \
   sbt sbtVersion
 
-WORKDIR /home/ubuntu/
-ADD ./fetch_repo_and_collect_coverage.sh /home/ubuntu/fetch_repo_and_collect_coverage.sh
+RUN echo "export PATH=$JAVA_HOME/bin:$PATH" >> $HOME_DIR/.bashrc
 
-ENTRYPOINT /home/ubuntu/fetch_repo_and_collect_coverage.sh ${REPO} ${TAG} ${CHALLENGE_ID}
+USER ubuntu
+
+WORKDIR $HOME_DIR
+ADD ./fetch_repo_and_collect_coverage.sh $HOME_DIR/fetch_repo_and_collect_coverage.sh
+
+ENTRYPOINT $HOME_DIR/fetch_repo_and_collect_coverage.sh ${REPO} ${TAG} ${CHALLENGE_ID}

--- a/containers/scala/README.md
+++ b/containers/scala/README.md
@@ -1,0 +1,15 @@
+# Scala code coverage
+
+Scripts for retrieving code coverage for `scala` related `tdl-runner` projects:
+
+- `Dockerfile` contains definition of the image to build and copies `fetch_repo_and_collect_coverage.sh` into the `/home/ubuntu` directory. Expects following environment variables to be available `REPO`, `TAG` and `CHALLENGE_ID`. 
+- The `buildDockerImage.sh` script builds the needed base docker image. It takes two parameters i.e. image name and image version, which by default are set (see script for default values).
+- `runDockerContainer.sh` checks if it can find the required image or else calls `buildDockerImage.sh`, then loads and run the docker image.
+- `fetch_repo_and_collect_coverage.sh` clones the repo inside the docker container, see usage. 
+
+Usage `fetch_repo_and_collect_coverage.sh`:
+
+Takes in 3 parameters:
+	- repo url i.e.  https://github.com/julianghionoiu/tdl-runner-scala.git    
+	- tag name i.e. xxx-2.0
+	- challengeId i.e. HLO

--- a/containers/scala/buildDockerImage.sh
+++ b/containers/scala/buildDockerImage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+dockerImageName=${1:-accelerate-io/dpnt-coverage-scala}
+dockerImageVersion=${2:-0.1}
+
+echo "Building docker image for with the name ${dockerImageName}:${dockerImageVersion}"
+docker build -t ${dockerImageName}:${dockerImageVersion} ${SCRIPT_CURRENT_DIR}/.
+
+echo "Remove any dangling images from the local registry"
+docker images -q -f dangling=true | xargs docker rmi -f  || true

--- a/containers/scala/buildDockerImage.sh
+++ b/containers/scala/buildDockerImage.sh
@@ -13,4 +13,5 @@ echo "Building docker image for with the name ${dockerImageName}:${dockerImageVe
 docker build -t ${dockerImageName}:${dockerImageVersion} ${SCRIPT_CURRENT_DIR}/.
 
 echo "Remove any dangling images from the local registry"
-docker images -q -f dangling=true | xargs docker rmi -f  || true
+imagesToRemove=$(docker images -q -f dangling=true)
+[ ! -z ${imagesToRemove} ] && docker rmi -f $imagesToRemove || true

--- a/containers/scala/buildDockerImage.sh
+++ b/containers/scala/buildDockerImage.sh
@@ -12,6 +12,5 @@ dockerImageVersion=${2:-0.1}
 echo "Building docker image for with the name ${dockerImageName}:${dockerImageVersion}"
 docker build -t ${dockerImageName}:${dockerImageVersion} ${SCRIPT_CURRENT_DIR}/.
 
-echo "Remove any dangling images from the local registry"
 imagesToRemove=$(docker images -q -f dangling=true)
-[ ! -z ${imagesToRemove} ] && docker rmi -f $imagesToRemove || true
+[ ! -z "${imagesToRemove}" ] && echo "Remove any dangling images from the local registry" && docker rmi -f $imagesToRemove || true

--- a/containers/scala/fetch_repo_and_collect_coverage.sh
+++ b/containers/scala/fetch_repo_and_collect_coverage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+REPO=$1
+TAG=$2
+CHALLENGE_ID=$3
+
+echo "Switching to $HOME and cloning repo: ${REPO}"
+git clone ${REPO} tdl-runner
+cd tdl-runner
+
+echo "Switching to tag: ${TAG}"
+git checkout ${TAG}
+git pull origin ${TAG}
+
+echo "Running script to retrieve the code coverage for ${CHALLENGE_ID} for the repo ${REPO}"
+./get_coverage_for_challenge.sh ${CHALLENGE_ID}

--- a/containers/scala/runDockerContainer.sh
+++ b/containers/scala/runDockerContainer.sh
@@ -13,16 +13,8 @@ CHALLENGE_ID=$3
 dockerImageName="accelerate-io/dpnt-coverage-scala"
 dockerImageVersion="0.1"
 
-echo "Checking for the presence of ${dockerImageName}":"${dockerImageVersion} in the local docker registry"
-foundDockerImage=$(docker images --filter="reference=${dockerImageName}" | grep "${dockerImageName}" || true)
-if [[ -z ${foundDockerImage} ]]; then
-  ${SCRIPT_CURRENT_DIR}/buildDockerImage.sh "${dockerImageName}" "${dockerImageVersion}"
-
-  if [[ $? -ne 0 ]]; then
-    echo "There was a problem building the docker image needed to run this task, process exited with error code '$?'"
-    exit -1
-  fi
-fi
+echo "Quickly triggering a re-build of the docker image '${dockerImageName}":"${dockerImageVersion}'"
+${SCRIPT_CURRENT_DIR}/buildDockerImage.sh "${dockerImageName}" "${dockerImageVersion}"
 
 echo "Running ${dockerImageName}":"${dockerImageVersion} from the local docker registry"
 docker run                                                                      \

--- a/containers/scala/runDockerContainer.sh
+++ b/containers/scala/runDockerContainer.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+SCRIPT_CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REPO=$1
+TAG=$2	
+CHALLENGE_ID=$3
+
+dockerImageName="accelerate-io/dpnt-coverage-scala"
+dockerImageVersion="0.1"
+
+echo "Checking for the presence of ${dockerImageName}":"${dockerImageVersion} in the local docker registry"
+foundDockerImage=$(docker images --filter="reference=${dockerImageName}" | grep "${dockerImageName}" || true)
+if [[ -z ${foundDockerImage} ]]; then
+  ${SCRIPT_CURRENT_DIR}/buildDockerImage.sh "${dockerImageName}" "${dockerImageVersion}"
+
+  if [[ $? -ne 0 ]]; then
+    echo "There was a problem building the docker image needed to run this task, process exited with error code '$?'"
+    exit -1
+  fi
+fi
+
+echo "Running ${dockerImageName}":"${dockerImageVersion} from the local docker registry"
+docker run                                                                      \
+      --rm                                                                      \
+      --interactive                                                             \
+      --workdir=/home/ubuntu                                                    \
+      --env REPO=${REPO}                                                        \
+      --env TAG=${TAG}                                                          \
+      --env CHALLENGE_ID=${CHALLENGE_ID}                                        \
+      ${dockerImageName}:${dockerImageVersion}

--- a/containers/scala/runDockerContainer.sh
+++ b/containers/scala/runDockerContainer.sh
@@ -19,8 +19,6 @@ ${SCRIPT_CURRENT_DIR}/buildDockerImage.sh "${dockerImageName}" "${dockerImageVer
 echo "Running ${dockerImageName}":"${dockerImageVersion} from the local docker registry"
 docker run                                                                      \
       --rm                                                                      \
-      --interactive                                                             \
-      --workdir=/home/ubuntu                                                    \
       --env REPO=${REPO}                                                        \
       --env TAG=${TAG}                                                          \
       --env CHALLENGE_ID=${CHALLENGE_ID}                                        \


### PR DESCRIPTION
- creates docker image with Java 8, Scala, SBT in it
- runs container taking in the respective parameters (repo, tag and challenge id as environment variables)
- runs fetch coverage script and returns value on the console (also saved in a .txt file in the `target` folder) 

Does not provide a cache for SBT/Scala via a volume, next thing to look into - potential TODO

Do we need to maintain any other kind of cache?

Target command to run (example):
```
./runDockerContainer.sh https://github.com/julianghionoiu/tdl-runner-scala.git add-sbt-code-coverage-config SUM
```
