### PR TITLE
Fix failing acceptance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ Build package
 
 Invoke function manually
 ```
-SLS_DEBUG=* serverless invoke local --function srcs-github-export --path tdl/dpnt-sourcecode/src/test/resources/tdl/datapoint/sourcecode/sample_s3_event.json
+SLS_DEBUG=* serverless invoke local --function srcs-github-export --path ../dpnt-sourcecode/src/test/resources/tdl/datapoint/sourcecode/sample_s3_via_sns_event.json
+```
+or
+
+```
+SLS_DEBUG=* serverless invoke local --function srcs-github-export --path src/test/resources/tdl/datapoint/sourcecode/sample_s3_via_sns_event.json
 ```
 
 ## Container deployment

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Otherwise see below:
 A note on the container networking. The container will attempt to call services on the docker host by using the `host.docker.internal` name.
 https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds. 
 
-Also see https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-docker-for-mac-host-internal
+Also see https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-docker-for-mac-host-internal (especially for Windows or MacOS)
 If this is not supported on your machine, you have the option of changing the hostname used to locate the Docker host:
 ```bash
 DOCKER_HOST_WITHIN_CONTAINER=host.docker.internal python local-ecs/ecs-server-wrapper.py start config/local.params.yml
@@ -64,9 +64,16 @@ or
 DOCKER_HOST_WITHIN_CONTAINER=n.n.n.n python local-ecs/ecs-server-wrapper.py start config/local.params.yml
 ```
 
-`host.docker.internal` should be static ip address or supported DNS entry of host (via Docker Host for Mac/Windows) on which the containers are running.
+#### Linux
+`host.docker.internal` or `n.n.n.n` static ip address (for e.g. 172.17.0.1) on which the containers are running  
 
-Run the acceptance test
+#### MacOS
+`docker.for.mac.host.internal` or `docker.for.mac.localhost` or `n.n.n.n` - supported DNS entry of host (via Docker Host for MacOS) on which the containers are running 
+
+#### Windows
+`docker.for.win.host.internal` or `docker.for.win.localhost` or `n.n.n.n` - supported DNS entry of host (via Docker Host for Windows) on which the containers are running
+
+### Run the acceptance test
 
 ```
 ./gradlew --rerun-tasks test jacocoTestReport

--- a/src/main/java/tdl/datapoint/coverage/CoverageUploadHandler.java
+++ b/src/main/java/tdl/datapoint/coverage/CoverageUploadHandler.java
@@ -13,7 +13,11 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.jgit.api.Git;
-import tdl.datapoint.coverage.processing.*;
+import tdl.datapoint.coverage.processing.ECSCoverageTaskRunner;
+import tdl.datapoint.coverage.processing.Language;
+import tdl.datapoint.coverage.processing.LocalGitClient;
+import tdl.datapoint.coverage.processing.S3BucketEvent;
+import tdl.datapoint.coverage.processing.S3SrcsToGitExporter;
 import tdl.participant.queue.connector.SqsEventQueue;
 import tdl.participant.queue.events.ProgrammingLanguageDetectedEvent;
 
@@ -25,7 +29,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static tdl.datapoint.coverage.ApplicationEnv.*;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_ENDPOINT;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_REGION;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_TASK_CLUSTER;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_TASK_DEFINITION_PREFIX;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_TASK_LAUNCH_TYPE;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_VPC_ASSIGN_PUBLIC_IP;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_VPC_SECURITY_GROUP;
+import static tdl.datapoint.coverage.ApplicationEnv.ECS_VPC_SUBNET;
+import static tdl.datapoint.coverage.ApplicationEnv.S3_ENDPOINT;
+import static tdl.datapoint.coverage.ApplicationEnv.S3_REGION;
+import static tdl.datapoint.coverage.ApplicationEnv.SQS_ENDPOINT;
+import static tdl.datapoint.coverage.ApplicationEnv.SQS_QUEUE_URL;
+import static tdl.datapoint.coverage.ApplicationEnv.SQS_REGION;
 
 public class CoverageUploadHandler implements RequestHandler<Map<String, Object>, String> {
     private static final Logger LOG = Logger.getLogger(CoverageUploadHandler.class.getName());
@@ -153,6 +169,4 @@ public class CoverageUploadHandler implements RequestHandler<Map<String, Object>
                     participantId, challengeId, roundId, language, doneTag);
         }
     }
-
-
 }

--- a/src/test/java/tdl/datapoint/coverage/CoverageDatapointAcceptanceTest.java
+++ b/src/test/java/tdl/datapoint/coverage/CoverageDatapointAcceptanceTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CoverageDatapointAcceptanceTest {
     private static final Context NO_CONTEXT = null;
+    private static final int WAIT_BEFORE_RETRY_IN_MILLIS = 2000;
+    private static final int TASK_FINISH_CHECK_RETRY_COUNT = 10;
 
     @Rule
     public EnvironmentVariables environmentVariables = new EnvironmentVariables();
@@ -138,8 +140,12 @@ public class CoverageDatapointAcceptanceTest {
 
     //~~~~~~~~~~ Helpers ~~~~~~~~~~~~~`
 
-    private static void waitForQueueToReceiveEvents() throws InterruptedException {
-        Thread.sleep(10000);
+    private void waitForQueueToReceiveEvents() throws InterruptedException {
+        int retryCtr = 0;
+        while ((coverageComputedEvents.size() < 2) && (retryCtr < TASK_FINISH_CHECK_RETRY_COUNT)) {
+            Thread.sleep(WAIT_BEFORE_RETRY_IN_MILLIS);
+            retryCtr++;
+        }
     }
 
     private static String generateId() {


### PR DESCRIPTION
- Updated README.md with more specific details on how to start the `ecs-server-wrapper.py` service and pass it the IP of the docker host to it

- Acceptance test amended to wait for the coverage step to complete and retry every 2 seconds for 10 times before timing out and failing