### PR TITLE
Fixing base components and its dependents [docker images and components]

### DIFF
--- a/container/images/base/Dockerfile
+++ b/container/images/base/Dockerfile
@@ -1,15 +1,31 @@
-FROM java:8u111-jdk
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+FROM buildpack-deps:stretch-scm
 
-RUN apt-get update && apt-get install -qy \
-    python-pip \
+# Install Java 8
+COPY --from=java:8u111-jdk /usr/lib/jvm /usr/lib/jvm
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+RUN echo "JAVA_HOME=${JAVA_HOME}"
+RUN echo "PATH=${PATH}"
+
+RUN rm -fr /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install --fix-missing && apt-get install -qy \
+    python3-pip \
     groff-base \
     git \
     libxml2-utils \
     jq \
     dos2unix \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
-RUN pip install awscli
+
+RUN python3 --version
+RUN python3 -m pip install --upgrade pip
+RUN pip --version
+
+RUN python3 -m pip install --user setuptools
+RUN pip install --user setuptools awscli
 
 ENV WORKDIR /srv
 WORKDIR ${WORKDIR}

--- a/container/images/base/Dockerfile
+++ b/container/images/base/Dockerfile
@@ -1,5 +1,11 @@
 FROM buildpack-deps:stretch-scm
 
+# Install python 3.7 by copy installed layers from another image
+COPY --from=python:3.7 / /
+
+RUN python3 --version
+RUN pip --version
+
 # Install Java 8
 COPY --from=java:8u111-jdk /usr/lib/jvm /usr/lib/jvm
 
@@ -11,8 +17,7 @@ RUN echo "PATH=${PATH}"
 
 RUN rm -fr /var/lib/apt/lists/*
 
-RUN apt-get update && apt-get install --fix-missing && apt-get install -qy \
-    python3-pip \
+RUN apt-get install --fix-missing && apt-get update && apt-get install -qy \
     groff-base \
     git \
     libxml2-utils \
@@ -20,11 +25,6 @@ RUN apt-get update && apt-get install --fix-missing && apt-get install -qy \
     dos2unix \
     --no-install-recommends && rm -r /var/lib/apt/lists/*
 
-RUN python3 --version
-RUN python3 -m pip install --upgrade pip
-RUN pip --version
-
-RUN python3 -m pip install --user setuptools
 RUN pip install --user setuptools awscli
 
 ENV WORKDIR /srv

--- a/container/images/dotnet-base/Dockerfile
+++ b/container/images/dotnet-base/Dockerfile
@@ -6,7 +6,7 @@ RUN uname -a
 RUN ln -s /usr/lib/apt/methods/http /usr/lib/apt/methods/https
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN apt-get update && apt-get -y install apt-transport-https curl
-RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-jessie main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list
 
 RUN apt-get update && apt-get install -qy \
     mono-devel     \

--- a/container/images/dotnet-base/Dockerfile
+++ b/container/images/dotnet-base/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 RUN uname -a
 
 RUN ln -s /usr/lib/apt/methods/http /usr/lib/apt/methods/https
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 RUN apt-get update && apt-get -y install apt-transport-https curl
 RUN echo "deb https://download.mono-project.com/repo/ubuntu stable-stretch main" | tee /etc/apt/sources.list.d/mono-official-stable.list
 

--- a/container/images/python/Dockerfile
+++ b/container/images/python/Dockerfile
@@ -1,8 +1,6 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as baseImage
 
-COPY --from=python:3.7 / /
-
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN ln -sf ${JAVA_HOME}/bin/java /usr/bin/java
 

--- a/container/images/ruby/Dockerfile
+++ b/container/images/ruby/Dockerfile
@@ -38,8 +38,8 @@ RUN apt-get update && apt-get install -qy \
 
 ### Hence, running the below, two, as recommend by gpg in the failure message
 
-RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg --no-tty --import -
+RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --no-tty --import -
 
 RUN curl -L get.rvm.io | bash -s stable
 ENV RVM_PATH  /usr/local/rvm

--- a/container/images/scala/Dockerfile
+++ b/container/images/scala/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
 ENV SCALA_VERSION 2.12.3
-ENV SBT_VERSION 0.13.8
+ENV SBT_VERSION 0.13.9
 # Install Scala
 ## Piping curl directly in tar
 RUN \
@@ -12,14 +12,16 @@ RUN \
 
 # Install sbt
 RUN \
-  curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+  wget -c https://bintray.com/artifact/download/sbt/debian/sbt-$SBT_VERSION.deb && \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
-  apt-get install sbt && \
-  sbt sbtVersion
+  apt-get install sbt
 
 # Precache dependencies for faster run - will populate the IVY cache
 ENV SBT_BUILD_TMP /tmp/sbt
 RUN mkdir -p ${SBT_BUILD_TMP} && \
     git clone --depth 1 https://github.com/julianghionoiu/tdl-runner-scala.git ${SBT_BUILD_TMP}
 RUN ( cd ${SBT_BUILD_TMP} && sbt --debug update )
+
+RUN scala -version
+RUN sbt sbtVersion

--- a/container/images/scala/Dockerfile
+++ b/container/images/scala/Dockerfile
@@ -1,21 +1,23 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
-ENV SCALA_VERSION 2.12.3
-ENV SBT_VERSION 0.13.9
+ENV SCALA_VERSION 2.12.8
+
 # Install Scala
-## Piping curl directly in tar
-RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
-  echo >> /root/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
+## Installing openjdk-8-jdk to prevent the jre-headless or jdk-headless errors from occurring
+RUN apt-get --fix-broken install
+RUN apt-get update && apt-get install -qy openjdk-8-jdk
+
+RUN wget www.scala-lang.org/files/archive/scala-$SCALA_VERSION.deb
+RUN dpkg -i scala-$SCALA_VERSION.deb
+RUN scala -version
 
 # Install sbt
-RUN \
-  wget -c https://bintray.com/artifact/download/sbt/debian/sbt-$SBT_VERSION.deb && \
-  dpkg -i sbt-$SBT_VERSION.deb && \
-  rm sbt-$SBT_VERSION.deb && \
-  apt-get install sbt
+## Not downloading a fixed version but expecting debian to give us one
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+RUN apt-get install apt-transport-https
+RUN apt-get update && apt-get install sbt
 
 # Precache dependencies for faster run - will populate the IVY cache
 ENV SBT_BUILD_TMP /tmp/sbt


### PR DESCRIPTION
Fixed underlying/base componets i.e. base, dotnet base.

So far the below languages have been successfully migrated:

- base
- java
- python
- nodejs
- ruby
- hmmm
- csharp
- fsharp
- vbnet
- scala

Purpose of the changes:
- base image was not building due to changes to underlying debian packages and the source lists (Error or invalid URLs)
- dotnot-base was not building  due to changes to underlying debian packages and the source lists (Error or invalid URLs) 
- scala image was also not building due to sbt installation failing again due to debian related changes

All container code coverage tests pass, hence upgrading the above containers do not have impact on the dependent containers.